### PR TITLE
Remove deprecated visibility control

### DIFF
--- a/franka_hardware/include/franka_hardware/franka_hardware_interface.hpp
+++ b/franka_hardware/include/franka_hardware/franka_hardware_interface.hpp
@@ -18,7 +18,6 @@
 #include <string>
 #include <vector>
 
-#include <hardware_interface/visibility_control.h>
 #include <franka_hardware/robot.hpp>
 
 #include <hardware_interface/hardware_info.hpp>


### PR DESCRIPTION
[This](https://github.com/ros-controls/ros2_control/pull/1972) PR and releasing `ros2_control` version [4.24.0](https://github.com/ros-controls/ros2_control/releases/tag/4.24.0) made visibility control headers deprecated in ROS2 Jazzy.

This PR removes it from `franka_hardware_interface`.