### PR TITLE
jazzy support

### DIFF
--- a/franka_description/package.xml
+++ b/franka_description/package.xml
@@ -17,6 +17,7 @@
   <exec_depend>xacro</exec_depend>
   <exec_depend>rviz2</exec_depend>
   <exec_depend>joint_state_publisher_gui</exec_depend>
+  <exec_depend>moveit_resources_panda_moveit_config</exec_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/franka_description/robots/panda_arm.ros2_control.xacro
+++ b/franka_description/robots/panda_arm.ros2_control.xacro
@@ -5,9 +5,9 @@
     <ros2_control name="FrankaHardwareInterface" type="system">
       <hardware>
         <xacro:if value="${use_fake_hardware}">
-          <plugin>fake_components/GenericSystem</plugin>
-          <param name="fake_sensor_commands">${fake_sensor_commands}</param>
-          <param name="state_following_offset">0.0</param>
+          <plugin>mock_components/GenericSystem</plugin>
+          <param name="mock_sensor_commands">${fake_sensor_commands}</param>
+          <param name="position_state_following_offset">0.0</param>
         </xacro:if>
         <xacro:unless value="${use_fake_hardware}">
           <plugin>franka_hardware/FrankaHardwareInterface</plugin>

--- a/franka_description/robots/panda_arm.ros2_control.xacro
+++ b/franka_description/robots/panda_arm.ros2_control.xacro
@@ -17,9 +17,10 @@
 
       <xacro:macro name="configure_joint" params="joint_name initial_position">
         <joint name="${joint_name}">
-          <param name="initial_position">${initial_position}</param>
           <command_interface name="effort"/>
-          <state_interface name="position"/>
+          <state_interface name="position">
+            <param name="initial_value">${initial_position}</param>
+          </state_interface>
           <state_interface name="velocity"/>
           <state_interface name="effort"/>
         </joint>

--- a/franka_description/robots/panda_arm.urdf.xacro
+++ b/franka_description/robots/panda_arm.urdf.xacro
@@ -13,6 +13,18 @@
     <xacro:include filename="$(find franka_description)/robots/hand.xacro"/>
     <xacro:hand ns="$(arg arm_id)" rpy="0 0 ${-pi/4}" connected_to="$(arg arm_id)_link8" safety_distance="0.03"/>
   </xacro:if>
-  <xacro:include filename="$(find franka_description)/robots/panda_arm.ros2_control.xacro"/>
-  <xacro:panda_arm_ros2_control ns="$(arg arm_id)" robot_ip="$(arg robot_ip)" use_fake_hardware="$(arg use_fake_hardware)" fake_sensor_commands="$(arg fake_sensor_commands)"/>
+
+  <xacro:unless value="$(arg use_fake_hardware)">
+    <xacro:include filename="$(find franka_description)/robots/panda_arm.ros2_control.xacro"/>
+    <xacro:panda_arm_ros2_control ns="$(arg arm_id)" robot_ip="$(arg robot_ip)" use_fake_hardware="$(arg use_fake_hardware)" fake_sensor_commands="$(arg fake_sensor_commands)"/>
+  </xacro:unless>
+
+  <xacro:if value="$(arg use_fake_hardware)">
+    <!-- mock system from 'moveit_resources_panda_moveit_config' -->
+    <!-- https://github.com/moveit/moveit_resources/blob/3.1.0/panda_moveit_config/config/panda.urdf.xacro -->
+    <xacro:include filename="$(find moveit_resources_panda_moveit_config)/config/panda.ros2_control.xacro"/>
+    <xacro:include filename="$(find moveit_resources_panda_moveit_config)/config/panda_hand.ros2_control.xacro"/>
+    <xacro:panda_ros2_control name="PandaFakeSystem" initial_positions_file="$(find moveit_resources_panda_moveit_config)/config/initial_positions.yaml" ros2_control_hardware_type="mock_components"/>
+    <xacro:panda_hand_ros2_control name="PandaHandFakeSystem" ros2_control_hardware_type="mock_components"/>
+  </xacro:if>
 </robot>

--- a/franka_description/test/urdf_tests.py
+++ b/franka_description/test/urdf_tests.py
@@ -35,7 +35,7 @@ def test_load_with_gripper():
 def test_load_with_fake_hardware():
     urdf = xacro.process_file(panda_xacro_file_name,
                               mappings={'use_fake_hardware': 'true'}).toxml()
-    assert urdf.find('fake_components/GenericSystem') != -1
+    assert urdf.find('mock_components/GenericSystem') != -1
 
 
 def test_load_with_robot_ip():

--- a/franka_hardware/include/franka_hardware/franka_hardware_interface.hpp
+++ b/franka_hardware/include/franka_hardware/franka_hardware_interface.hpp
@@ -18,7 +18,6 @@
 #include <string>
 #include <vector>
 
-#include <hardware_interface/visibility_control.h>
 #include <franka_hardware/robot.hpp>
 
 #include <hardware_interface/hardware_info.hpp>

--- a/franka_moveit_config/launch/moveit.launch.py
+++ b/franka_moveit_config/launch/moveit.launch.py
@@ -129,7 +129,7 @@ def generate_launch_description():
         parameters=[
             robot_description,
             robot_description_semantic,
-            kinematics_yaml,
+            {'robot_description_kinematics': kinematics_yaml},
             ompl_planning_pipeline_config,
             trajectory_execution,
             moveit_controllers,
@@ -151,7 +151,7 @@ def generate_launch_description():
             robot_description,
             robot_description_semantic,
             ompl_planning_pipeline_config,
-            kinematics_yaml,
+            {'robot_description_kinematics': kinematics_yaml},
         ],
     )
 

--- a/franka_moveit_config/launch/moveit.launch.py
+++ b/franka_moveit_config/launch/moveit.launch.py
@@ -79,6 +79,10 @@ def generate_launch_description():
         'franka_moveit_config', 'config/kinematics.yaml'
     )
 
+    joint_limits_yaml = load_yaml(
+        'moveit_resources_panda_moveit_config', 'config/joint_limits.yaml'
+    )
+
     # Planning Functionality
     ompl_planning_pipeline_config = {
         'move_group': {
@@ -130,6 +134,7 @@ def generate_launch_description():
             robot_description,
             robot_description_semantic,
             {'robot_description_kinematics': kinematics_yaml},
+            {'robot_description_planning': joint_limits_yaml},
             ompl_planning_pipeline_config,
             trajectory_execution,
             moveit_controllers,

--- a/franka_moveit_config/launch/moveit.launch.py
+++ b/franka_moveit_config/launch/moveit.launch.py
@@ -23,10 +23,40 @@ from launch.actions import (DeclareLaunchArgument, ExecuteProcess, IncludeLaunch
                             SetEnvironmentVariable, Shutdown)
 from launch.conditions import UnlessCondition
 from launch.launch_description_sources import PythonLaunchDescriptionSource
-from launch.substitutions import Command, FindExecutable, LaunchConfiguration, PathJoinSubstitution
+from launch.substitution import Substitution
+from launch.substitutions import (Command, FindExecutable, LaunchConfiguration,
+                                  NotSubstitution, PathJoinSubstitution)
 from launch_ros.actions import Node
 from launch_ros.substitutions import FindPackageShare
 import yaml
+
+
+# backport 'IfElseSubstitution' from 'launch':
+# https://github.com/ros2/launch/blob/3.7.1/launch/launch/substitutions/if_else_substitution.py
+class CustomIfElseSubstitution(Substitution):
+    def __init__(self, condition, if_value, else_value) -> None:
+        from launch.utilities import normalize_to_list_of_substitutions
+        super().__init__()
+        self._condition = normalize_to_list_of_substitutions(condition)
+        self._if_value = normalize_to_list_of_substitutions(if_value)
+        self._else_value = normalize_to_list_of_substitutions(else_value)
+
+    @classmethod
+    def parse(cls, data):
+        kwargs = {'condition': data[0], 'if_value': data[1], 'else_value': data[2]}
+        return cls, kwargs
+
+    def describe(self):
+        return f'IfElseSubstitution({self._condition}, {self._if_value}, {self._else_value})'
+
+    def perform(self, context):
+        from launch.utilities import perform_substitutions
+        from launch.utilities.type_utils import perform_typed_substitution
+
+        if perform_typed_substitution(context, self._condition, bool):
+            return perform_substitutions(context, self._if_value)
+        else:
+            return perform_substitutions(context, self._else_value)
 
 
 def load_yaml(package_name, file_path):
@@ -169,11 +199,18 @@ def generate_launch_description():
         parameters=[robot_description],
     )
 
-    ros2_controllers_path = os.path.join(
-        get_package_share_directory('franka_moveit_config'),
-        'config',
-        'panda_ros_controllers.yaml',
+    ros2_controllers_path = CustomIfElseSubstitution(
+        condition=NotSubstitution(use_fake_hardware),
+        if_value=os.path.join(
+            get_package_share_directory('franka_moveit_config'),
+            'config', 'panda_ros_controllers.yaml',
+        ),
+        else_value=os.path.join(
+            get_package_share_directory('moveit_resources_panda_moveit_config'),
+            'config', 'ros2_controllers.yaml',
+        ),
     )
+
     ros2_control_node = Node(
         package='controller_manager',
         executable='ros2_control_node',

--- a/franka_moveit_config/launch/moveit.launch.py
+++ b/franka_moveit_config/launch/moveit.launch.py
@@ -20,7 +20,7 @@ import os
 from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
 from launch.actions import (DeclareLaunchArgument, ExecuteProcess, IncludeLaunchDescription,
-                            Shutdown)
+                            SetEnvironmentVariable, Shutdown)
 from launch.conditions import UnlessCondition
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch.substitutions import Command, FindExecutable, LaunchConfiguration, PathJoinSubstitution
@@ -181,6 +181,8 @@ def generate_launch_description():
         on_exit=Shutdown(),
     )
 
+    env_lc = SetEnvironmentVariable(name='LC_NUMERIC', value='C')
+
     # Load controllers
     load_controllers = []
     for controller in ['panda_arm_controller', 'joint_state_broadcaster']:
@@ -228,7 +230,8 @@ def generate_launch_description():
                           use_fake_hardware_parameter_name: use_fake_hardware}.items(),
     )
     return LaunchDescription(
-        [robot_arg,
+        [env_lc,
+         robot_arg,
          use_fake_hardware_arg,
          fake_sensor_commands_arg,
          db_arg,
@@ -238,7 +241,7 @@ def generate_launch_description():
          ros2_control_node,
          joint_state_publisher,
          franka_robot_state_broadcaster,
-         gripper_launch_file
+         gripper_launch_file,
          ]
         + load_controllers
     )

--- a/franka_moveit_config/package.xml
+++ b/franka_moveit_config/package.xml
@@ -20,6 +20,7 @@
   <exec_depend>moveit_ros_move_group</exec_depend>
   <exec_depend>moveit_kinematics</exec_depend>
   <exec_depend>moveit_planners_ompl</exec_depend>
+  <exec_depend>moveit_simple_controller_manager</exec_depend>
   <exec_depend>moveit_ros_visualization</exec_depend>
   <exec_depend>rviz2</exec_depend>
   <exec_depend>xacro</exec_depend>

--- a/franka_moveit_config/package.xml
+++ b/franka_moveit_config/package.xml
@@ -21,6 +21,7 @@
   <exec_depend>moveit_kinematics</exec_depend>
   <exec_depend>moveit_planners_ompl</exec_depend>
   <exec_depend>moveit_simple_controller_manager</exec_depend>
+  <exec_depend>moveit_resources_panda_moveit_config</exec_depend>
   <exec_depend>moveit_ros_visualization</exec_depend>
   <exec_depend>rviz2</exec_depend>
   <exec_depend>xacro</exec_depend>

--- a/franka_robot_state_broadcaster/include/franka_robot_state_broadcaster/franka_robot_state_broadcaster.hpp
+++ b/franka_robot_state_broadcaster/include/franka_robot_state_broadcaster/franka_robot_state_broadcaster.hpp
@@ -19,8 +19,8 @@
 #include <unordered_map>
 #include <vector>
 
+#include <franka_robot_state_broadcaster/franka_robot_state_broadcaster_parameters.hpp>
 #include "controller_interface/controller_interface.hpp"
-#include "franka_robot_state_broadcaster_parameters.hpp"
 #include "franka_semantic_components/franka_robot_state.hpp"
 #include "rclcpp_lifecycle/lifecycle_publisher.hpp"
 #include "rclcpp_lifecycle/node_interfaces/lifecycle_node_interface.hpp"

--- a/franka_robot_state_broadcaster/package.xml
+++ b/franka_robot_state_broadcaster/package.xml
@@ -8,7 +8,6 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
-  <depend>backward_ros</depend>
   <depend>builtin_interfaces</depend>
   <depend>control_msgs</depend>
   <depend>controller_interface</depend>

--- a/integration_launch_testing/package.xml
+++ b/integration_launch_testing/package.xml
@@ -8,14 +8,14 @@
   <license>Apache 2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
-  
+
   <test_depend>ament_cmake_copyright</test_depend>
   <test_depend>ament_cmake_flake8</test_depend>
   <test_depend>ament_cmake_lint_cmake</test_depend>
   <test_depend>ament_cmake_pep257</test_depend>
   <test_depend>ament_cmake_xmllint</test_depend>
   <test_depend>launch_testing_ament_cmake</test_depend>
-  
+
   <export>
     <build_type>ament_cmake</build_type>
   </export>

--- a/integration_launch_testing/package.xml
+++ b/integration_launch_testing/package.xml
@@ -14,7 +14,7 @@
   <test_depend>ament_cmake_lint_cmake</test_depend>
   <test_depend>ament_cmake_pep257</test_depend>
   <test_depend>ament_cmake_xmllint</test_depend>
-  <test_depend>launch_testing</test_depend>
+  <test_depend>launch_testing_ament_cmake</test_depend>
   
   <export>
     <build_type>ament_cmake</build_type>


### PR DESCRIPTION
This fixes warnings and errors with deprecated headers and generally updates the code and configuration to make the controllers compatible with ROS 2 jazzy, such that
```sh
ros2 launch franka_bringup franka.launch.py robot_ip:=$ROBOT_IP
```
works on `humble` and `jazzy`.

This does not include compatibility updates to the MoveIt configuration. The `moveit.launch.py`:
```sh
ros2 launch franka_moveit_config moveit.launch.py robot_ip:=$ROBOT_IP
```
only works with ROS 2 `humble`. On `jazzy`, this fails with:
```
terminate called after throwing an instance of 'rclcpp::ParameterTypeException'
  what():  expected [string_array] got [string]
```

To make the MoveIt 2 configuration in `moveit.launch.py` compatible with `jazzy`, you further have to convert the string parameters `planning_plugin` and `request_adapters` into lists:
```diff
--- a/franka_moveit_config/launch/moveit.launch.py
+++ b/franka_moveit_config/launch/moveit.launch.py
@@ -116,13 +116,18 @@ def generate_launch_description():
     # Planning Functionality
     ompl_planning_pipeline_config = {
         'move_group': {
-            'planning_plugin': 'ompl_interface/OMPLPlanner',
-            'request_adapters': 'default_planner_request_adapters/AddTimeOptimalParameterization '
-                                'default_planner_request_adapters/ResolveConstraintFrames '
-                                'default_planner_request_adapters/FixWorkspaceBounds '
-                                'default_planner_request_adapters/FixStartStateBounds '
-                                'default_planner_request_adapters/FixStartStateCollision '
-                                'default_planner_request_adapters/FixStartStatePathConstraints',
+            'planning_plugins': ['ompl_interface/OMPLPlanner'],
+            'request_adapters': [
+                'default_planning_request_adapters/ResolveConstraintFrames',
+                'default_planning_request_adapters/ValidateWorkspaceBounds',
+                'default_planning_request_adapters/CheckStartStateBounds',
+                'default_planning_request_adapters/CheckStartStateCollision',
+            ],
+            'response_adapters': [
+                'default_planning_response_adapters/AddTimeOptimalParameterization',
+                'default_planning_response_adapters/ValidateSolution',
+                'default_planning_response_adapters/DisplayMotionPath',
+            ],
             'start_state_max_bounds_error': 0.1,
         }
     }
```

However, this change to the parameter types will make this PR incompatible to `humble`. Hence, the hardware interface and controllers will be compatible with `humble` and `jazzy`, while the default launch file will keep its compatibility with `humble` only.

I recommend deriving your own MoveIt launch file from the launch file in this repo and apply these changes manually. Alternatively, use the [MoveIt Setup Assistant](https://moveit.picknik.ai/main/doc/examples/setup_assistant/setup_assistant_tutorial.html) to generate a new configuration from scratch.